### PR TITLE
feat(checks): add fail early option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add a "Fail early" option to the broker, consumer group, partition and topic lag checks. When enabled, the check fails as soon as a deviating event is observed; when disabled, it keeps collecting events for the whole duration and only fails at the end of the step. The broker/consumer-group/partition checks default to fail-early (matching their previous behavior); the topic lag check defaults to fail-at-end (matching its previous behavior). Only affects the "All the time" mode of the mode-based checks.
+
 ## v1.2.16
 
 - build(deps): bump actions/checkout from 6 to 7

--- a/extkafka/check_brokers.go
+++ b/extkafka/check_brokers.go
@@ -274,7 +274,11 @@ func BrokerCheckStatus(ctx context.Context, state *CheckBrokersState) (*action_k
 			})
 		} else {
 			state.DeviationSeen = true
-			state.DeviationTitle = title
+			// Keep the first-seen deviation, which is usually the most actionable, rather than
+			// letting a later deviation (this poll or a subsequent one) overwrite it.
+			if state.DeviationTitle == "" {
+				state.DeviationTitle = title
+			}
 		}
 	}
 

--- a/extkafka/check_brokers.go
+++ b/extkafka/check_brokers.go
@@ -31,8 +31,13 @@ type CheckBrokersState struct {
 	ExpectedChanges    []string
 	StateCheckMode     string
 	StateCheckSuccess  bool
-	BrokerHosts        []string
-	ClusterName        string // Cluster name for multi-cluster support
+	FailEarly          bool
+	// DeviationSeen and DeviationTitle are used in 'fail at end' mode (FailEarly = false) to remember
+	// that a deviating change was observed during the step so the failure can be reported once the step ends.
+	DeviationSeen     bool
+	DeviationTitle    string
+	BrokerHosts       []string
+	ClusterName       string // Cluster name for multi-cluster support
 }
 
 const (
@@ -120,6 +125,15 @@ func (m *CheckBrokersAction) Describe() action_kit_api.ActionDescription {
 				}),
 				Required: new(true),
 			},
+			{
+				Name:         "failEarly",
+				Label:        "Fail early",
+				Description:  new("If enabled, the check fails as soon as a deviating change is observed. If disabled, the check keeps collecting events for the whole duration and only fails at the end of the step. Only affects the 'All the time' mode; 'At least once' can only be evaluated at the end of the step."),
+				Type:         action_kit_api.ActionParameterTypeBoolean,
+				DefaultValue: new("true"),
+				Advanced:     new(true),
+				Required:     new(false),
+			},
 		},
 		Widgets: new([]action_kit_api.Widget{
 			action_kit_api.StateOverTimeWidget{
@@ -186,6 +200,12 @@ func (m *CheckBrokersAction) Prepare(ctx context.Context, state *CheckBrokersSta
 		return nil, new(extension_kit.ToError(fmt.Sprintf("Failed to retrieve brokers from Kafka. Full response: %v", err), err))
 	}
 
+	// Default to failing early to preserve the previous behavior for experiments that don't set this parameter.
+	state.FailEarly = true
+	if request.Config["failEarly"] != nil {
+		state.FailEarly = extutil.ToBool(request.Config["failEarly"])
+	}
+
 	state.End = end
 	state.ExpectedChanges = expectedState
 	state.StateCheckMode = stateCheckMode
@@ -243,25 +263,34 @@ func BrokerCheckStatus(ctx context.Context, state *CheckBrokersState) (*action_k
 		keys = append(keys, k)
 	}
 
+	// recordDeviation either fails immediately (fail early) or remembers the deviation so it can be
+	// reported once the step ends (fail at end). The broker change messages are already phrased in the
+	// past tense, so the same message reads correctly in both cases.
+	recordDeviation := func(title string) {
+		if state.FailEarly {
+			checkError = new(action_kit_api.ActionKitError{
+				Title:  title,
+				Status: extutil.Ptr(action_kit_api.Failed),
+			})
+		} else {
+			state.DeviationSeen = true
+			state.DeviationTitle = title
+		}
+	}
+
 	if len(state.ExpectedChanges) > 0 {
 		if state.StateCheckMode == stateCheckModeAllTheTime {
 			for _, c := range keys {
 				if !slices.Contains(state.ExpectedChanges, c) {
-					checkError = new(action_kit_api.ActionKitError{
-						Title: fmt.Sprintf("Brokers got an unexpected change '%s' whereas '%s' is expected.",
-							c,
-							state.ExpectedChanges),
-						Status: extutil.Ptr(action_kit_api.Failed),
-					})
+					recordDeviation(fmt.Sprintf("Brokers got an unexpected change '%s' whereas '%s' is expected.",
+						c,
+						state.ExpectedChanges))
 				}
 			}
 			if len(changes) == 0 {
-				checkError = new(action_kit_api.ActionKitError{
-					Title: fmt.Sprintf("Brokers got an unexpected change '%v' whereas '%s' is expected.",
-						"No changes",
-						state.ExpectedChanges),
-					Status: extutil.Ptr(action_kit_api.Failed),
-				})
+				recordDeviation(fmt.Sprintf("Brokers got an unexpected change '%v' whereas '%s' is expected.",
+					"No changes",
+					state.ExpectedChanges))
 			}
 		} else if state.StateCheckMode == stateCheckModeAtLeastOnce {
 			for _, c := range keys {
@@ -280,13 +309,17 @@ func BrokerCheckStatus(ctx context.Context, state *CheckBrokersState) (*action_k
 		}
 	} else {
 		if len(changes) > 0 {
-			checkError = new(action_kit_api.ActionKitError{
-				Title: fmt.Sprintf("Brokers got an unexpected change '%v' whereas '%s' is expected.",
-					keys,
-					"No changes"),
-				Status: extutil.Ptr(action_kit_api.Failed),
-			})
+			recordDeviation(fmt.Sprintf("Brokers got an unexpected change '%v' whereas '%s' is expected.",
+				keys,
+				"No changes"))
 		}
+	}
+
+	if !state.FailEarly && completed && state.DeviationSeen {
+		checkError = new(action_kit_api.ActionKitError{
+			Title:  state.DeviationTitle,
+			Status: extutil.Ptr(action_kit_api.Failed),
+		})
 	}
 
 	metrics := []action_kit_api.Metric{

--- a/extkafka/check_brokers_test.go
+++ b/extkafka/check_brokers_test.go
@@ -101,6 +101,7 @@ func TestCheckBrokers_Prepare(t *testing.T) {
 				assert.Equal(t, tt.wantedState.ExpectedChanges, state.ExpectedChanges)
 				assert.Equal(t, tt.wantedState.StateCheckMode, state.StateCheckMode)
 				assert.Equal(t, tt.wantedState.StateCheckSuccess, state.StateCheckSuccess)
+				assert.True(t, state.FailEarly) // defaults to true when not provided (non-breaking)
 				assert.NotNil(t, state.End)
 			}
 		})

--- a/extkafka/check_consumer_group.go
+++ b/extkafka/check_consumer_group.go
@@ -269,11 +269,14 @@ func ConsumerGroupCheckStatus(ctx context.Context, state *ConsumerGroupCheckStat
 				} else {
 					// Keep collecting events and remember the deviation to report it at the end of the
 					// step (past tense - the state may have recovered by the time this is reported).
+					// Keep the first-seen deviation rather than letting a later one overwrite it.
 					state.DeviationSeen = true
-					state.DeviationTitle = fmt.Sprintf("Consumer Group '%s' had state '%s' whereas '%s' is expected.",
-						group.Group,
-						group.State,
-						state.ExpectedState)
+					if state.DeviationTitle == "" {
+						state.DeviationTitle = fmt.Sprintf("Consumer Group '%s' had state '%s' whereas '%s' is expected.",
+							group.Group,
+							group.State,
+							state.ExpectedState)
+					}
 				}
 			}
 			if !state.FailEarly && completed && state.DeviationSeen {

--- a/extkafka/check_consumer_group.go
+++ b/extkafka/check_consumer_group.go
@@ -29,8 +29,13 @@ type ConsumerGroupCheckState struct {
 	ExpectedState     []string
 	StateCheckMode    string
 	StateCheckSuccess bool
-	BrokerHosts       []string
-	ClusterName       string // Cluster name for multi-cluster support
+	FailEarly         bool
+	// DeviationSeen and DeviationTitle are used in 'fail at end' mode (FailEarly = false) to remember
+	// that a deviating state was observed during the step so the failure can be reported once the step ends.
+	DeviationSeen  bool
+	DeviationTitle string
+	BrokerHosts    []string
+	ClusterName    string // Cluster name for multi-cluster support
 }
 
 // Make sure action implements all required interfaces
@@ -129,6 +134,15 @@ func (m *ConsumerGroupCheckAction) Describe() action_kit_api.ActionDescription {
 				}),
 				Required: new(true),
 			},
+			{
+				Name:         "failEarly",
+				Label:        "Fail early",
+				Description:  new("If enabled, the check fails as soon as a deviating state is observed. If disabled, the check keeps collecting events for the whole duration and only fails at the end of the step. Only affects the 'All the time' mode; 'At least once' can only be evaluated at the end of the step."),
+				Type:         action_kit_api.ActionParameterTypeBoolean,
+				DefaultValue: new("true"),
+				Advanced:     new(true),
+				Required:     new(false),
+			},
 		},
 		Widgets: new([]action_kit_api.Widget{
 			action_kit_api.StateOverTimeWidget{
@@ -176,6 +190,12 @@ func (m *ConsumerGroupCheckAction) Prepare(_ context.Context, state *ConsumerGro
 	var stateCheckMode string
 	if request.Config["stateCheckMode"] != nil {
 		stateCheckMode = fmt.Sprintf("%v", request.Config["stateCheckMode"])
+	}
+
+	// Default to failing early to preserve the previous behavior for experiments that don't set this parameter.
+	state.FailEarly = true
+	if request.Config["failEarly"] != nil {
+		state.FailEarly = extutil.ToBool(request.Config["failEarly"])
 	}
 
 	// Get cluster name from target
@@ -237,11 +257,28 @@ func ConsumerGroupCheckStatus(ctx context.Context, state *ConsumerGroupCheckStat
 	if len(state.ExpectedState) > 0 {
 		if state.StateCheckMode == stateCheckModeAllTheTime {
 			if !slices.Contains(state.ExpectedState, group.State) {
-				checkError = new(action_kit_api.ActionKitError{
-					Title: fmt.Sprintf("Consumer Group '%s' has state '%s' whereas '%s' is expected.",
+				if state.FailEarly {
+					// Fail as soon as a deviating state is observed (present tense - it is deviating now).
+					checkError = new(action_kit_api.ActionKitError{
+						Title: fmt.Sprintf("Consumer Group '%s' has state '%s' whereas '%s' is expected.",
+							group.Group,
+							group.State,
+							state.ExpectedState),
+						Status: extutil.Ptr(action_kit_api.Failed),
+					})
+				} else {
+					// Keep collecting events and remember the deviation to report it at the end of the
+					// step (past tense - the state may have recovered by the time this is reported).
+					state.DeviationSeen = true
+					state.DeviationTitle = fmt.Sprintf("Consumer Group '%s' had state '%s' whereas '%s' is expected.",
 						group.Group,
 						group.State,
-						state.ExpectedState),
+						state.ExpectedState)
+				}
+			}
+			if !state.FailEarly && completed && state.DeviationSeen {
+				checkError = new(action_kit_api.ActionKitError{
+					Title:  state.DeviationTitle,
 					Status: extutil.Ptr(action_kit_api.Failed),
 				})
 			}

--- a/extkafka/check_consumer_group_test.go
+++ b/extkafka/check_consumer_group_test.go
@@ -111,6 +111,7 @@ func TestCheckConsumerGroup_Prepare(t *testing.T) {
 				assert.Equal(t, tt.wantedState.ConsumerGroupName, state.ConsumerGroupName)
 				assert.Equal(t, tt.wantedState.ExpectedState, state.ExpectedState)
 				assert.False(t, state.StateCheckSuccess)
+				assert.True(t, state.FailEarly) // defaults to true when not provided (non-breaking)
 				assert.NotNil(t, state.End)
 			}
 		})

--- a/extkafka/check_partitions.go
+++ b/extkafka/check_partitions.go
@@ -33,8 +33,13 @@ type PartitionsCheckState struct {
 	ExpectedChanges         []string
 	StateCheckMode          string
 	StateCheckSuccess       bool
-	BrokerHosts             []string
-	ClusterName             string // Cluster name for multi-cluster support
+	FailEarly               bool
+	// DeviationSeen and DeviationTitle are used in 'fail at end' mode (FailEarly = false) to remember
+	// that a deviating change was observed during the step so the failure can be reported once the step ends.
+	DeviationSeen  bool
+	DeviationTitle string
+	BrokerHosts    []string
+	ClusterName    string // Cluster name for multi-cluster support
 }
 
 const (
@@ -132,6 +137,15 @@ func (m *PartitionsCheckAction) Describe() action_kit_api.ActionDescription {
 				}),
 				Required: new(true),
 			},
+			{
+				Name:         "failEarly",
+				Label:        "Fail early",
+				Description:  new("If enabled, the check fails as soon as a deviating change is observed. If disabled, the check keeps collecting events for the whole duration and only fails at the end of the step. Only affects the 'All the time' mode; 'At least once' can only be evaluated at the end of the step."),
+				Type:         action_kit_api.ActionParameterTypeBoolean,
+				DefaultValue: new("true"),
+				Advanced:     new(true),
+				Required:     new(false),
+			},
 		},
 		Widgets: new([]action_kit_api.Widget{
 			action_kit_api.StateOverTimeWidget{
@@ -180,6 +194,12 @@ func (m *PartitionsCheckAction) Prepare(_ context.Context, state *PartitionsChec
 	var stateCheckMode string
 	if request.Config["changeCheckMode"] != nil {
 		stateCheckMode = fmt.Sprintf("%v", request.Config["changeCheckMode"])
+	}
+
+	// Default to failing early to preserve the previous behavior for experiments that don't set this parameter.
+	state.FailEarly = true
+	if request.Config["failEarly"] != nil {
+		state.FailEarly = extutil.ToBool(request.Config["failEarly"])
 	}
 
 	// Get cluster name from target
@@ -290,15 +310,33 @@ func TopicCheckStatus(ctx context.Context, state *PartitionsCheckState) (*action
 		if state.StateCheckMode == stateCheckModeAllTheTime {
 			for _, c := range keys {
 				if !slices.Contains(state.ExpectedChanges, c) {
-					checkError = new(action_kit_api.ActionKitError{
-						Title: fmt.Sprintf("Topic '%s' has an unexpected change '%s' whereas '%s' is expected. Change(s) : %v",
+					if state.FailEarly {
+						// Fail as soon as a deviating change is observed (present tense - it is deviating now).
+						checkError = new(action_kit_api.ActionKitError{
+							Title: fmt.Sprintf("Topic '%s' has an unexpected change '%s' whereas '%s' is expected. Change(s) : %v",
+								state.TopicName,
+								c,
+								state.ExpectedChanges,
+								changes[c]),
+							Status: extutil.Ptr(action_kit_api.Failed),
+						})
+					} else {
+						// Keep collecting events and remember the deviation to report it at the end of the
+						// step (past tense - the topic may have recovered by the time this is reported).
+						state.DeviationSeen = true
+						state.DeviationTitle = fmt.Sprintf("Topic '%s' had an unexpected change '%s' whereas '%s' is expected. Change(s) : %v",
 							state.TopicName,
 							c,
 							state.ExpectedChanges,
-							changes[c]),
-						Status: extutil.Ptr(action_kit_api.Failed),
-					})
+							changes[c])
+					}
 				}
+			}
+			if !state.FailEarly && completed && state.DeviationSeen {
+				checkError = new(action_kit_api.ActionKitError{
+					Title:  state.DeviationTitle,
+					Status: extutil.Ptr(action_kit_api.Failed),
+				})
 			}
 		} else if state.StateCheckMode == stateCheckModeAtLeastOnce {
 			for _, c := range keys {

--- a/extkafka/check_partitions.go
+++ b/extkafka/check_partitions.go
@@ -323,12 +323,15 @@ func TopicCheckStatus(ctx context.Context, state *PartitionsCheckState) (*action
 					} else {
 						// Keep collecting events and remember the deviation to report it at the end of the
 						// step (past tense - the topic may have recovered by the time this is reported).
+						// Keep the first-seen deviation rather than letting a later one overwrite it.
 						state.DeviationSeen = true
-						state.DeviationTitle = fmt.Sprintf("Topic '%s' had an unexpected change '%s' whereas '%s' is expected. Change(s) : %v",
-							state.TopicName,
-							c,
-							state.ExpectedChanges,
-							changes[c])
+						if state.DeviationTitle == "" {
+							state.DeviationTitle = fmt.Sprintf("Topic '%s' had an unexpected change '%s' whereas '%s' is expected. Change(s) : %v",
+								state.TopicName,
+								c,
+								state.ExpectedChanges,
+								changes[c])
+						}
 					}
 				}
 			}

--- a/extkafka/check_topic_lag_for_consumer.go
+++ b/extkafka/check_topic_lag_for_consumer.go
@@ -29,6 +29,7 @@ type ConsumerGroupLagCheckState struct {
 	AcceptableLag     int64
 	StateCheckSuccess bool
 	StateCheckFailed  bool
+	FailEarly         bool
 	BrokerHosts       []string
 	ClusterName       string // Cluster name for multi-cluster support
 }
@@ -98,6 +99,15 @@ func (m *ConsumerGroupLagCheckAction) Describe() action_kit_api.ActionDescriptio
 				Required:     new(true),
 				DefaultValue: new("10"),
 			},
+			{
+				Name:         "failEarly",
+				Label:        "Fail early",
+				Description:  new("If enabled, the check fails as soon as the lag exceeds the threshold. If disabled (the default, matching the previous behavior), the check keeps collecting lag for the whole duration and only fails at the end of the step."),
+				Type:         action_kit_api.ActionParameterTypeBoolean,
+				DefaultValue: new("false"),
+				Advanced:     new(true),
+				Required:     new(false),
+			},
 		},
 		Widgets: new([]action_kit_api.Widget{
 			action_kit_api.LineChartWidget{
@@ -157,6 +167,12 @@ func (m *ConsumerGroupLagCheckAction) Prepare(_ context.Context, state *Consumer
 	state.Topic = extutil.ToString(request.Config["topic"])
 	state.AcceptableLag = extutil.ToInt64(request.Config["acceptableLag"])
 	state.StateCheckFailed = false
+	// Default to failing at the end to preserve the previous behavior for experiments that don't set
+	// this parameter (this check historically only reported a lag breach once the step ended).
+	state.FailEarly = false
+	if request.Config["failEarly"] != nil {
+		state.FailEarly = extutil.ToBool(request.Config["failEarly"])
+	}
 
 	duration := request.Config["duration"].(float64)
 	end := time.Now().Add(time.Millisecond * time.Duration(duration))
@@ -228,12 +244,22 @@ func ConsumerGroupLagCheckStatus(ctx context.Context, state *ConsumerGroupLagChe
 	} else {
 		state.StateCheckFailed = true
 	}
-	if completed && state.StateCheckFailed {
-		checkError = new(action_kit_api.ActionKitError{
-			Title: fmt.Sprintf("Consumer Group Lag was higher at least once than acceptable threshold  '%d'.",
-				state.AcceptableLag),
-			Status: extutil.Ptr(action_kit_api.Failed),
-		})
+	if state.StateCheckFailed {
+		if state.FailEarly {
+			// Fail as soon as the lag exceeds the threshold (present tense - it is too high now).
+			checkError = new(action_kit_api.ActionKitError{
+				Title: fmt.Sprintf("Consumer Group Lag is higher than the acceptable threshold '%d'.",
+					state.AcceptableLag),
+				Status: extutil.Ptr(action_kit_api.Failed),
+			})
+		} else if completed {
+			// Otherwise only report the breach once the step ends (past tense - it may have recovered).
+			checkError = new(action_kit_api.ActionKitError{
+				Title: fmt.Sprintf("Consumer Group Lag was higher at least once than acceptable threshold  '%d'.",
+					state.AcceptableLag),
+				Status: extutil.Ptr(action_kit_api.Failed),
+			})
+		}
 	}
 
 	metrics := []action_kit_api.Metric{

--- a/extkafka/check_topic_lag_for_consumer.go
+++ b/extkafka/check_topic_lag_for_consumer.go
@@ -239,27 +239,29 @@ func ConsumerGroupLagCheckStatus(ctx context.Context, state *ConsumerGroupLagChe
 
 	completed := now.After(state.End)
 	var checkError *action_kit_api.ActionKitError
-	if topicLag < state.AcceptableLag {
-		state.StateCheckSuccess = true
-	} else {
+	breaching := topicLag >= state.AcceptableLag
+	if breaching {
 		state.StateCheckFailed = true
+	} else {
+		state.StateCheckSuccess = true
 	}
-	if state.StateCheckFailed {
-		if state.FailEarly {
-			// Fail as soon as the lag exceeds the threshold (present tense - it is too high now).
+	if state.FailEarly {
+		// Fail while the lag is currently over the threshold (present tense), evaluated per poll so the
+		// check recovers when the lag drops back - consistent with the other fail-early checks.
+		if breaching {
 			checkError = new(action_kit_api.ActionKitError{
 				Title: fmt.Sprintf("Consumer Group Lag is higher than the acceptable threshold '%d'.",
 					state.AcceptableLag),
 				Status: extutil.Ptr(action_kit_api.Failed),
 			})
-		} else if completed {
-			// Otherwise only report the breach once the step ends (past tense - it may have recovered).
-			checkError = new(action_kit_api.ActionKitError{
-				Title: fmt.Sprintf("Consumer Group Lag was higher at least once than acceptable threshold  '%d'.",
-					state.AcceptableLag),
-				Status: extutil.Ptr(action_kit_api.Failed),
-			})
 		}
+	} else if completed && state.StateCheckFailed {
+		// Otherwise only report a breach once the step ends (past tense - it may have recovered).
+		checkError = new(action_kit_api.ActionKitError{
+			Title: fmt.Sprintf("Consumer Group Lag was higher at least once than acceptable threshold  '%d'.",
+				state.AcceptableLag),
+			Status: extutil.Ptr(action_kit_api.Failed),
+		})
 	}
 
 	metrics := []action_kit_api.Metric{

--- a/extkafka/check_topic_lag_for_consumer_test.go
+++ b/extkafka/check_topic_lag_for_consumer_test.go
@@ -109,6 +109,7 @@ func TestCheckConsumerGroupLag_Prepare(t *testing.T) {
 				assert.Equal(t, state.ConsumerGroupName, state.ConsumerGroupName)
 				assert.Equal(t, state.Topic, state.Topic)
 				assert.False(t, state.StateCheckSuccess)
+				assert.False(t, state.FailEarly) // defaults to false for this check (preserves fail-at-end behavior)
 				assert.NotNil(t, state.End)
 			}
 		})


### PR DESCRIPTION
## Problem

The ending time of our checks isn't consistently applied, which makes experiments hard to time. A check can fail early (on the first deviating event) or only at the end of the step, with no way to choose. This adds a per-check option, following the reference implementation in `extension-datadog` (and matching dynatrace/grafana).

## Change

Adds a **`failEarly` boolean** to all four Kafka checks (broker, consumer group, partition, topic lag):

- **Enabled** — the check fails as soon as a deviating event is observed.
- **Disabled** — the check keeps collecting events for the whole step duration and only fails at the end.

Parameter lives in the **Advanced** section, is **optional**, and reads the deviation back at completion via `DeviationSeen`/`DeviationTitle` (mode-based checks) or the existing `StateCheckFailed` (topic lag).

### Defaults preserve today's behavior (per the ticket: "default may differ per action")

| Check | Default | Why |
|-------|---------|-----|
| Broker / Consumer group / Partition | **fail early** (`true`) | their `All the time` mode already failed on the first deviation |
| **Topic lag** | **fail at end** (`false`) | it only ever reported a lag breach once the step ended |

So existing experiments are non-breaking across the board. The mode-based option only affects `All the time`; `At least once` can only be evaluated at the end.

### Message wording

For checks whose deviation message was present tense (consumer group "has state", partition "has an unexpected change"), the fail-at-end message uses **past tense** ("had state" / "had an unexpected change"), since the state may have recovered by the time it is reported. The broker messages ("got an unexpected change") and topic-lag end message ("was higher … at least once") were already historical, so they are reused as-is.

## Tests

- Asserted the `FailEarly` default in the existing Prepare tests: `true` for broker & consumer group, `false` for topic lag.
- Existing `kfake`-cluster Status tests continue to pass (they drive `Prepare`, so they exercise the default).
- All `extkafka` tests pass, `go vet` clean.