### PR TITLE
chore(deps): bump go to 1.26.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   extension-ci:
     uses: steadybit/extension-kit/.github/workflows/reusable-extension-ci.yml@main # NOSONAR githubactions:S7637 - our own action
     with:
-      go_version: '^1.26.4'
+      go_version: '^1.26.5'
       runs_on: steadybit_runner_ubuntu_latest_4cores_16GB
       build_linux_packages: true
       run_make_prepare_audit: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steadybit/extension-kafka
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5

--- a/test-dataset/dummyconsumer/go.mod
+++ b/test-dataset/dummyconsumer/go.mod
@@ -1,6 +1,6 @@
 module github.com/steadybit/extension-kafka/dummyconsummer
 
-go 1.25.3
+go 1.26.5
 
 require (
 	github.com/rs/zerolog v1.34.0


### PR DESCRIPTION
Bump Go to 1.26.5 in go.mod and CI. Also ran `go fix` and `go mod tidy`.