### PR TITLE
refactor: register extension index via exthttp.RegisterRevisionedHandler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,15 +8,15 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/rs/zerolog v1.35.1
 	github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5
-	github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1
+	github.com/steadybit/action-kit/go/action_kit_sdk v1.4.0
 	github.com/steadybit/action-kit/go/action_kit_test v1.4.7
 	github.com/steadybit/advice-kit/go/advice_kit_api v1.2.4
 	github.com/steadybit/discovery-kit/go/discovery_kit_api v1.7.1
 	github.com/steadybit/discovery-kit/go/discovery_kit_commons v0.3.1
-	github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5
+	github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.4.0
 	github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1
 	github.com/steadybit/event-kit/go/event_kit_api v1.6.2
-	github.com/steadybit/extension-kit v1.10.5
+	github.com/steadybit/extension-kit v1.11.0
 	github.com/stretchr/testify v1.11.1
 	github.com/twmb/franz-go v1.21.3
 	github.com/twmb/franz-go/pkg/kadm v1.18.0
@@ -51,7 +51,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/klauspost/compress v1.19.0 // indirect
 	github.com/mailru/easyjson v0.9.2 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dv
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.19.0 h1:sXLILfc9jV2QYWkzFOPWStmcUVH2RHEB1JCdY2oVvCQ=
+github.com/klauspost/compress v1.19.0/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -184,6 +186,8 @@ github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5 h1:WQkcNX2us3JyOrdn
 github.com/steadybit/action-kit/go/action_kit_api/v2 v2.10.5/go.mod h1:g8gkKZCnaZaxtQseZ/L6/flv3Hutwy0xcVO7P1cbUMQ=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1 h1:c83hiU+RLWjqouWR9baiidmYcTtDTdRa5rkWKFvdbc8=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.3.1/go.mod h1:DMMqDn4QNetxAoEXSpS7xF/vV+aD6YIDl/CgWOi5ii8=
+github.com/steadybit/action-kit/go/action_kit_sdk v1.4.0 h1:FPLsWpJ/mdMrZ8BaYXDOjcEvYs4U1EcXw04UQtom1Is=
+github.com/steadybit/action-kit/go/action_kit_sdk v1.4.0/go.mod h1:NNpAxqUQOLZaEtaenRrOTBWKsFw9XcNaHzWPtF6EvF4=
 github.com/steadybit/action-kit/go/action_kit_test v1.4.7 h1:DyW3xYKQTOpCy4GLOShUXYpzfTXH/JgWOcUi5WeC55k=
 github.com/steadybit/action-kit/go/action_kit_test v1.4.7/go.mod h1:wtXttqkPYMWNsnp3TgBJiimeW0SsNrP0niUMirXo8FM=
 github.com/steadybit/advice-kit/go/advice_kit_api v1.2.4 h1:fIgGR0WVWFGBYwuhVDg/i8m59GmCJCUc2A9kCplt2iE=
@@ -194,12 +198,16 @@ github.com/steadybit/discovery-kit/go/discovery_kit_commons v0.3.1 h1:b+Q2f0soE6
 github.com/steadybit/discovery-kit/go/discovery_kit_commons v0.3.1/go.mod h1:tDHrNzndAnllw1Wj8m0OiPxt7qctr34xSkyKBGhR+Wg=
 github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5 h1:1yT/4Aw+lQvYXSCen8L/RgJmh/z4eC5dEccwBp9ABOY=
 github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5/go.mod h1:gOPfHZ3hw/7TMxEYCCTYnOz9tZ2ybNYa+MKmUbPXKIQ=
+github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.4.0 h1:XQby2P3UY8VsAqQTwjMJ4BIacfn5VHiPutJDMEumYhg=
+github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.4.0/go.mod h1:D4SiKJKisSW3O9kZL4g/EIe3ewbjdMIQUICt7aA7tcU=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1 h1:CabRtfE70gt/4H/TgL/TRm54OkxWKbmPhTX2qEhzKZ4=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1/go.mod h1:PPJh5gSdVRKG/0qJCGJK5XnGxXat/v6UT8/2ilIbbX8=
 github.com/steadybit/event-kit/go/event_kit_api v1.6.2 h1:v2aA54GgCh1PNKm9+VRExCNDnpveLC9+DU9ErNJ6NPg=
 github.com/steadybit/event-kit/go/event_kit_api v1.6.2/go.mod h1:FitW7bd50/DptgPPm0uFfY90qTiNtfPX1IbCRuC37n8=
 github.com/steadybit/extension-kit v1.10.5 h1:KSZP2vUA97QnFDhI3UAAmNg1iOv4n0ckXI/jjKrB3xc=
 github.com/steadybit/extension-kit v1.10.5/go.mod h1:n1PMz8AwjGvl/M/CWSVjoHCE8qM74Tx+nfC4iiuhEPA=
+github.com/steadybit/extension-kit v1.11.0 h1:sliZpOlZKp0XuPKoH3pNyKzI0Tt3iYDCfwaoga5jriw=
+github.com/steadybit/extension-kit v1.11.0/go.mod h1:Bm3pbDipaVc64zpxfOEL9Shpr5CNd4By2x4/jSSr0bA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
 github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=

--- a/main.go
+++ b/main.go
@@ -38,8 +38,6 @@ import (
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 )
 
-var startedAt = time.Now().Format(time.RFC3339)
-
 func main() {
 	// Most Steadybit extensions leverage zerolog. To encourage persistent logging setups across extensions,
 	// you may leverage the extlogging package to initialize zerolog. Among others, this package supports
@@ -121,7 +119,7 @@ func registerHandlers(ctx context.Context) {
 	action_kit_sdk.RegisterAction(extkafka.NewPartitionsCheckAction())
 	action_kit_sdk.RegisterAction(extkafka.NewBrokersCheckAction())
 
-	exthttp.RegisterHttpHandler("/", exthttp.IfNoneMatchHandler(func() string { return startedAt }, exthttp.GetterAsHandler(getExtensionList)))
+	exthttp.RegisterRevisionedHandler("/", getExtensionList)
 }
 
 func SignalCanceledContext() (context.Context, context.CancelFunc) {


### PR DESCRIPTION
Replaces the hand-rolled `startedAt` + `IfNoneMatchHandler` index wiring with `exthttp.RegisterRevisionedHandler`, so the index ETag is centralized in the SDK and reflects registration state instead of process start.

Bumps `extension-kit` to v1.11.0 and the SDK kits it uses to the releases that bump the revision on register/clear. Behavior is unchanged for existing agents; the ETag value stays an unquoted string that round-trips as before.