### PR TITLE
chore: run CI on free ubuntu-latest runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     uses: steadybit/extension-kit/.github/workflows/reusable-extension-ci.yml@main # NOSONAR githubactions:S7637 - our own action
     with:
       go_version: '^1.26.5'
-      runs_on: steadybit_runner_ubuntu_latest_4cores_16GB
+      runs_on: ubuntu-latest
       build_linux_packages: true
       run_make_prepare_audit: true
       VERSION_BUMPER_APPID: ${{ vars.GH_APP_STEADYBIT_APP_ID }}


### PR DESCRIPTION
## What
Switch the CI `audit` job (via the `reusable-extension-ci.yml` `runs_on` input) from the billed larger runner `steadybit_runner_ubuntu_latest_4cores_16GB` to the standard **`ubuntu-latest`** runner.

## Why
This is a **public** repo, where the standard runner is 4 vCPU / 16 GB and standard-runner minutes are **free/unlimited**. The larger runner has identical specs but is billed, so this drops the cost to $0 with no change in resources or architecture.

## Scope & safety
- Only the `audit` job is affected; `build-consumer-image` and multi-arch Docker builds already run on `ubuntu-latest`.
- Testcontainers/Kafka-based tests confirmed passing on the standard runner.