### PR TITLE
fix: emit broker/consumer group check metrics immediately on Start

### DIFF
--- a/extkafka/check_brokers.go
+++ b/extkafka/check_brokers.go
@@ -216,8 +216,17 @@ func (m *CheckBrokersAction) Prepare(ctx context.Context, state *CheckBrokersSta
 	return nil, nil
 }
 
-func (m *CheckBrokersAction) Start(_ context.Context, _ *CheckBrokersState) (*action_kit_api.StartResult, error) {
-	return nil, nil
+func (m *CheckBrokersAction) Start(ctx context.Context, state *CheckBrokersState) (*action_kit_api.StartResult, error) {
+	statusResult, err := BrokerCheckStatus(ctx, state)
+	if statusResult == nil {
+		return nil, err
+	}
+	return &action_kit_api.StartResult{
+		Artifacts: statusResult.Artifacts,
+		Error:     statusResult.Error,
+		Messages:  statusResult.Messages,
+		Metrics:   statusResult.Metrics,
+	}, err
 }
 
 func (m *CheckBrokersAction) Status(ctx context.Context, state *CheckBrokersState) (*action_kit_api.StatusResult, error) {

--- a/extkafka/check_consumer_group.go
+++ b/extkafka/check_consumer_group.go
@@ -215,8 +215,17 @@ func (m *ConsumerGroupCheckAction) Prepare(_ context.Context, state *ConsumerGro
 	return nil, nil
 }
 
-func (m *ConsumerGroupCheckAction) Start(_ context.Context, _ *ConsumerGroupCheckState) (*action_kit_api.StartResult, error) {
-	return nil, nil
+func (m *ConsumerGroupCheckAction) Start(ctx context.Context, state *ConsumerGroupCheckState) (*action_kit_api.StartResult, error) {
+	statusResult, err := ConsumerGroupCheckStatus(ctx, state)
+	if statusResult == nil {
+		return nil, err
+	}
+	return &action_kit_api.StartResult{
+		Artifacts: statusResult.Artifacts,
+		Error:     statusResult.Error,
+		Messages:  statusResult.Messages,
+		Metrics:   statusResult.Metrics,
+	}, err
 }
 
 func (m *ConsumerGroupCheckAction) Status(ctx context.Context, state *ConsumerGroupCheckState) (*action_kit_api.StatusResult, error) {


### PR DESCRIPTION
## Summary
- `Start()` was a no-op for both `Check Brokers` and `Check Consumer State`, so the first metric only appeared after the first `Status()` poll (one `CallInterval` — 2s and 1s respectively — after the check started).
- `Start()` now reuses the same status-check logic as `Status()` for both actions, so the first metric is emitted immediately when the check starts.

## Test plan
- [x] `go build ./...`
- [x] `go test ./extkafka/...`