### PR TITLE
fix: emit partition/lag check metrics immediately on Start

### DIFF
--- a/extkafka/check_partitions.go
+++ b/extkafka/check_partitions.go
@@ -222,8 +222,17 @@ func (m *PartitionsCheckAction) Prepare(_ context.Context, state *PartitionsChec
 	return nil, nil
 }
 
-func (m *PartitionsCheckAction) Start(_ context.Context, _ *PartitionsCheckState) (*action_kit_api.StartResult, error) {
-	return nil, nil
+func (m *PartitionsCheckAction) Start(ctx context.Context, state *PartitionsCheckState) (*action_kit_api.StartResult, error) {
+	statusResult, err := TopicCheckStatus(ctx, state)
+	if statusResult == nil {
+		return nil, err
+	}
+	return &action_kit_api.StartResult{
+		Artifacts: statusResult.Artifacts,
+		Error:     statusResult.Error,
+		Messages:  statusResult.Messages,
+		Metrics:   statusResult.Metrics,
+	}, err
 }
 
 func (m *PartitionsCheckAction) Status(ctx context.Context, state *PartitionsCheckState) (*action_kit_api.StatusResult, error) {

--- a/extkafka/check_topic_lag_for_consumer.go
+++ b/extkafka/check_topic_lag_for_consumer.go
@@ -192,8 +192,17 @@ func (m *ConsumerGroupLagCheckAction) Prepare(_ context.Context, state *Consumer
 	return nil, nil
 }
 
-func (m *ConsumerGroupLagCheckAction) Start(_ context.Context, _ *ConsumerGroupLagCheckState) (*action_kit_api.StartResult, error) {
-	return nil, nil
+func (m *ConsumerGroupLagCheckAction) Start(ctx context.Context, state *ConsumerGroupLagCheckState) (*action_kit_api.StartResult, error) {
+	statusResult, err := ConsumerGroupLagCheckStatus(ctx, state)
+	if statusResult == nil {
+		return nil, err
+	}
+	return &action_kit_api.StartResult{
+		Artifacts: statusResult.Artifacts,
+		Error:     statusResult.Error,
+		Messages:  statusResult.Messages,
+		Metrics:   statusResult.Metrics,
+	}, err
 }
 
 func (m *ConsumerGroupLagCheckAction) Status(ctx context.Context, state *ConsumerGroupLagCheckState) (*action_kit_api.StatusResult, error) {


### PR DESCRIPTION
## Summary
- `Start()` was a no-op for both `Check Partitions` and `Check Topic Lag`, so the first metric only appeared after the first `Status()` poll (one `CallInterval` — 2s and 1s respectively — after the check started).
- `Start()` now reuses the same status-check logic as `Status()` for both actions, so the first metric is emitted immediately when the check starts.

(Note: `check_partitions.go` uses a `StateOverTimeWidget`, not `LineChartWidget` — only `check_topic_lag_for_consumer.go` is LineChart. Grouping it with this batch since it needed the same fix and had been missed in the earlier check_brokers/check_consumer_group PR.)

## Test plan
- [x] `go build ./...`
- [x] `go test ./extkafka/...`